### PR TITLE
Moved around autocloseable

### DIFF
--- a/src/main/java/com/kovisoft/simple/connection/pool/exports/ConnectionWrapper.java
+++ b/src/main/java/com/kovisoft/simple/connection/pool/exports/ConnectionWrapper.java
@@ -5,7 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 
-public interface ConnectionWrapper extends AutoCloseable {
+public interface ConnectionWrapper {
 
     //These really don't matter outside the pool, but they are there if you want them for some reason;
     boolean hasExpired();
@@ -14,6 +14,7 @@ public interface ConnectionWrapper extends AutoCloseable {
     Integer getPid();
     Connection borrowConnection();
     boolean inUse();
+
 
     /**
      * Allows you to explicitly release a connection, can help with pool management,
@@ -46,7 +47,7 @@ public interface ConnectionWrapper extends AutoCloseable {
      * you used a non cached statement.
      * @throws NullPointerException Exception thrown for a null key
      */
-    public PreparedStatement getPreparedStatement(String keyOrStmtString, int statementConst)
+    PreparedStatement getPreparedStatement(String keyOrStmtString, int statementConst)
             throws NullPointerException, SQLException;
 
 }

--- a/src/main/java/com/kovisoft/simple/connection/pool/exports/PoolFactory.java
+++ b/src/main/java/com/kovisoft/simple/connection/pool/exports/PoolFactory.java
@@ -3,7 +3,6 @@ package com.kovisoft.simple.connection.pool.exports;
 import com.kovisoft.simple.connection.pool.pg.ConnectionWrapperImpl;
 import com.kovisoft.simple.connection.pool.pg.SimplePgConnectionPoolImpl;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
 

--- a/src/main/java/com/kovisoft/simple/connection/pool/exports/SimpleConnectionPool.java
+++ b/src/main/java/com/kovisoft/simple/connection/pool/exports/SimpleConnectionPool.java
@@ -1,9 +1,9 @@
 package com.kovisoft.simple.connection.pool.exports;
 
-import java.sql.Connection;
+
 import java.sql.SQLException;
 
-public interface SimpleConnectionPool extends AutoCloseable{
+public interface SimpleConnectionPool {
 
     /**
      * Borrows a connection from the pool. The default pg implementation
@@ -29,9 +29,9 @@ public interface SimpleConnectionPool extends AutoCloseable{
 
 
     /**
-     * Tells the connection pool to shut down.
+     * Tells the connection pool to shut down. Exception comes from the mostly graceful shutdown.
      */
-    void shutDownPool();
+    void shutDownPool() throws Exception;
 
 
 }

--- a/src/main/java/com/kovisoft/simple/connection/pool/pg/ConnectionWrapperImpl.java
+++ b/src/main/java/com/kovisoft/simple/connection/pool/pg/ConnectionWrapperImpl.java
@@ -8,7 +8,7 @@ import java.sql.*;
 import java.time.LocalDateTime;
 import java.util.*;
 
-public class ConnectionWrapperImpl implements ConnectionWrapper {
+public class ConnectionWrapperImpl implements ConnectionWrapper, AutoCloseable {
 
     private static final Logger logger = LoggerFactory.createLogger(System.getProperty("user.dir") + "/logs", "DB_pool_");
     private static final String GET_PID = "SELECT pid FROM pg_stat_activity WHERE pid = pg_backend_pid();";

--- a/src/test/java/com/kovisoft/simple/connection/pool/exports/TestPoolFactory.java
+++ b/src/test/java/com/kovisoft/simple/connection/pool/exports/TestPoolFactory.java
@@ -27,7 +27,7 @@ public class TestPoolFactory {
         }
 
         @AfterAll
-        public static void tearDownPool() throws InterruptedException {
+        public static void tearDownPool() {
             Assertions.assertDoesNotThrow(() -> pool.shutDownPool());
         }
 
@@ -35,13 +35,12 @@ public class TestPoolFactory {
         @Test
         public void testCreateDefaultPool(){
             Assertions.assertDoesNotThrow(() -> {
-                try(SimplePgConnectionPool pool = PoolFactory.createDefaultPgPool(url, user, pass)){
-                    Assertions.assertNotNull(pool);
-                    Assertions.assertNotNull(pool.borrowConnection());
-                    Map<String, String> testMap = new HashMap<>(){{put("key", "SELECT 1");}};
-                    Assertions.assertEquals(1, pool.addPreparedStatementsToPool(testMap));
-                    pool.shutDownPool();
-                }
+                SimplePgConnectionPool pool = PoolFactory.createDefaultPgPool(url, user, pass);
+                Assertions.assertNotNull(pool);
+                Assertions.assertNotNull(pool.borrowConnection());
+                Map<String, String> testMap = new HashMap<>(){{put("key", "SELECT 1");}};
+                Assertions.assertEquals(1, pool.addPreparedStatementsToPool(testMap));
+                pool.shutDownPool();
             });
         }
 


### PR DESCRIPTION
It was not intended to make a user see the resources as autocloseable, the implementations need to be closeable, additionally added a separate thread to validation connections on a fixed 5-minute schedule.